### PR TITLE
Lut 25281

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/business/ITransitionDAO.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/ITransitionDAO.java
@@ -125,6 +125,17 @@ public interface ITransitionDAO
     List<Transition> selectTransitionsListFromStep( int nIdStep, Plugin plugin );
 
     /**
+     * Load the data of all the transition objects from given step (next step id) and returns them as a list
+     *
+     * @param nIdStep
+     *            The identifier of the Next step (the step where the transition leads to)
+     * @param plugin
+     *            the Plugin
+     * @return The list which contains the data of all the transition objects
+     */
+    List<Transition> selectTransitionsListByNextStepIdAndForm(int nIdStep, Plugin plugin);
+
+    /**
      * Load the data of a transition object from the given step and the given priority
      * 
      * @param nIdStep

--- a/src/java/fr/paris/lutece/plugins/forms/business/TransitionDAO.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/TransitionDAO.java
@@ -58,6 +58,7 @@ public final class TransitionDAO implements ITransitionDAO
     private static final String SQL_ORDER_BY_PRIORITY = " ORDER BY priority ASC";
     private static final String SQL_QUERY_SELECTALL_ID = "SELECT id_transition FROM forms_transition";
     private static final String SQL_FILTER_BY_STEP = " WHERE t.from_step = ? " + SQL_ORDER_BY_PRIORITY;
+    private static final String SQL_FILTER_BY_NEXT_STEP_ID = " WHERE t.next_step = ? " + SQL_ORDER_BY_PRIORITY;
     private static final String SQL_FILTER_BY_FORM = " WHERE f.id_form = ? " + SQL_ORDER_BY_PRIORITY;
     private static final String SQL_FILTER_BY_STEP_AND_PRIORITY = " WHERE t.from_step = ? AND t.priority = ?";
     private static final String SQL_QUERY_SELECT_MAX_PRIORITY_BY_STEP = " SELECT MAX( t.priority ) FROM forms_transition t WHERE t.from_step = ?";
@@ -221,6 +222,23 @@ public final class TransitionDAO implements ITransitionDAO
         List<Transition> transitionList = new ArrayList<>( );
 
         try ( DAOUtil daoUtil = new DAOUtil( SQL_QUERY_SELECT + SQL_FILTER_BY_STEP, plugin ) )
+        {
+            daoUtil.setInt( 1, nIdStep );
+            daoUtil.executeQuery( );
+
+            while ( daoUtil.next( ) )
+            {
+                transitionList.add( dataToObject( daoUtil ) );
+            }
+        }
+        return transitionList;
+    }
+    @Override
+    public List<Transition> selectTransitionsListByNextStepIdAndForm (int nIdStep, Plugin plugin)
+    {
+        List<Transition> transitionList = new ArrayList<>( );
+
+        try ( DAOUtil daoUtil = new DAOUtil( SQL_QUERY_SELECT + SQL_FILTER_BY_NEXT_STEP_ID, plugin ) )
         {
             daoUtil.setInt( 1, nIdStep );
             daoUtil.executeQuery( );

--- a/src/java/fr/paris/lutece/plugins/forms/business/TransitionHome.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/TransitionHome.java
@@ -166,7 +166,17 @@ public final class TransitionHome
     {
         return _dao.selectTransitionsListFromStep( nIdStep, _plugin );
     }
-
+    /**
+     * Load the data of all the transition objects from the given step(the next step column of a transition) and returns them as a list
+     *
+     * @param nIdStep
+     *            The identifier of the next step (the step where the transition leads to)
+     * @return the list which contains the data of all the transition objects
+     */
+    public static List<Transition> selectTransitionsListByNextStepIdAndForm( int nIdStep )
+    {
+        return _dao.selectTransitionsListByNextStepIdAndForm( nIdStep, _plugin );
+    }
     /**
      * Load the data of a transition object from the given step and the given priority
      * 

--- a/src/java/fr/paris/lutece/plugins/forms/service/FormService.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/FormService.java
@@ -474,6 +474,8 @@ public class FormService
         if ( CollectionUtils.isNotEmpty( listFormResponse ) )
         {
             formResponseManager = new FormResponseManager( listFormResponse.get( 0 ) );
+            formResponseManager.setIsResponseLoadedFromBackup(true);
+
         }
         else
         {

--- a/src/java/fr/paris/lutece/plugins/forms/util/FormsResponseUtils.java
+++ b/src/java/fr/paris/lutece/plugins/forms/util/FormsResponseUtils.java
@@ -260,8 +260,23 @@ public class FormsResponseUtils
         }
 
         return null;
-    }   
-    
+    }
+
+    /**
+      * Build previous Step object
+     */
+    public static Step getPreviousStep( int nIdCurrentStep )
+    {
+        List<Transition> listTransition = TransitionHome.selectTransitionsListByNextStepIdAndForm( nIdCurrentStep );
+
+        if ( listTransition.size( ) == 0 )
+        {
+            return null;
+        }
+
+        return StepHome.findByPrimaryKey( listTransition.get( 0 ).getFromStep( ) );
+    }
+
     /**
      * Populate form with Physical File logo and number of response
      * @param form the form object

--- a/src/java/fr/paris/lutece/plugins/forms/util/FormsResponseUtils.java
+++ b/src/java/fr/paris/lutece/plugins/forms/util/FormsResponseUtils.java
@@ -263,7 +263,7 @@ public class FormsResponseUtils
     }
 
     /**
-      * Build previous Step object
+     * From a step, get the previous step with the highest priority
      */
     public static Step getPreviousStep( int nIdCurrentStep )
     {

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
@@ -167,6 +167,9 @@ public class FormResponseManager
     	return _bIsResponseLoadedFromBackup;
     }
 
+    public void setIsResponseLoadedFromBackup (Boolean bIsResponseLoadedFromBackup) {
+    	_bIsResponseLoadedFromBackup = bIsResponseLoadedFromBackup;
+    }
     /**
      * Initializes the steps order
      */

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
@@ -63,6 +63,8 @@ public class FormResponseManager
 {
     private final List<Step> _listValidatedStep;
     private final FormResponse _formResponse;
+    private boolean _bIsResponseLoadedFromBackup = false;
+
 
     /**
      * Constructor
@@ -159,6 +161,10 @@ public class FormResponseManager
     		updateDate = formResponseFromDB != null ? formResponseFromDB.getUpdate() : null;
     	}
     	return updateDate;
+    }
+
+    public Boolean getIsResponseLoadedFromBackup () {
+    	return _bIsResponseLoadedFromBackup;
     }
 
     /**

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
@@ -472,8 +472,22 @@ public class FormXPage extends MVCApplication
         }
         _formResponseManager.popStep( );
 
-        _currentStep = _formResponseManager.getCurrentStep( );
-
+  if(_formResponseManager.getCurrentStep( ) == null)
+        {
+     /*       int currentStepId = Integer.parseInt( request.getParameter( FormsConstants.PARAMETER_ID_STEP ) );
+         List<Step> formSteps =         StepHome.getStepsListByForm(_formResponseManager.getFormResponse().getFormId());
+        _currentStep = formSteps.stream().filter(step -> step.getId() == currentStepId).findFirst().get();
+*/
+            _currentStep =  FormsResponseUtils.getPreviousStep(Integer.parseInt( request.getParameter( FormsConstants.PARAMETER_ID_STEP ) ) );
+        //   _formResponseManager.findResponsesFor(_currentStep);
+            try {
+                FormsResponseUtils.fillResponseManagerWithResponses(request, false, _formResponseManager, _stepDisplayTree.getQuestions(), false);
+            } catch (QuestionValidationException exception) {
+                return getStepView(request);
+            }
+        } else {
+       _currentStep = _formResponseManager.getCurrentStep( );
+      }
         _stepDisplayTree = new StepDisplayTree( _currentStep.getId( ), _formResponseManager.getFormResponse( ) );
 
         return  getStepView(  request );
@@ -1019,7 +1033,7 @@ public class FormXPage extends MVCApplication
         FormResponse formResponse = _formResponseManager.getFormResponse( );
 
         _formService.removeFormBackup( formResponse );
-        _formResponseManager = new FormResponseManager( formResponse );
+        _formResponseManager = null;
         init( form.getId( ) );
 
         return getStepView(  request );
@@ -1208,9 +1222,9 @@ public class FormXPage extends MVCApplication
     private void initFormResponseManager( HttpServletRequest request, Form form )
     {
         LuteceUser user = SecurityService.getInstance( ).getRegisteredUser( request );
-        if ( _formResponseManager == null || !_formResponseManager.getIsResponseLoadedFromBackup())
+        if ( _formResponseManager == null || !_formResponseManager.getIsResponseLoadedFromBackup() && form.isBackupEnabled())
         {
-            if ( user != null  && form.isBackupEnabled() )
+            if ( user != null )
             {
                 _formResponseManager = _formService.createFormResponseManagerFromBackUp( form, user.getName( ) );
             }

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
@@ -474,17 +474,7 @@ public class FormXPage extends MVCApplication
 
   if(_formResponseManager.getCurrentStep( ) == null)
         {
-     /*       int currentStepId = Integer.parseInt( request.getParameter( FormsConstants.PARAMETER_ID_STEP ) );
-         List<Step> formSteps =         StepHome.getStepsListByForm(_formResponseManager.getFormResponse().getFormId());
-        _currentStep = formSteps.stream().filter(step -> step.getId() == currentStepId).findFirst().get();
-*/
             _currentStep =  FormsResponseUtils.getPreviousStep(Integer.parseInt( request.getParameter( FormsConstants.PARAMETER_ID_STEP ) ) );
-        //   _formResponseManager.findResponsesFor(_currentStep);
-            try {
-                FormsResponseUtils.fillResponseManagerWithResponses(request, false, _formResponseManager, _stepDisplayTree.getQuestions(), false);
-            } catch (QuestionValidationException exception) {
-                return getStepView(request);
-            }
         } else {
        _currentStep = _formResponseManager.getCurrentStep( );
       }

--- a/webapp/WEB-INF/templates/skin/plugins/forms/composite_template/view_step.html
+++ b/webapp/WEB-INF/templates/skin/plugins/forms/composite_template/view_step.html
@@ -10,6 +10,8 @@
   	<input type="hidden" name="token" value = "${token}">
 	<input name="page" value="forms" type="hidden">
 	<input name="id_form" value="${step.idForm}" type="hidden">
+      <input name="id_step" value="${step.id}" type="hidden">
+
 	<#if !step.initial><button class="btn btn-primary btn-sm" name="action_doReturnStep"  type="submit" >#i18n{forms.step.previous}</button></#if>
 	<#if step.final>
       <#if form.displaySummary >


### PR DESCRIPTION
- Fix access backup response to user, on forms that has the "save backup response" enable and no "mandatory authentication".
The problem was due to FormResponseManager not null (the condition to load backup responses), if you first go to first go to the page, FormResponseManager intanciates (before user logs in).. As when authentication is mandatory, you first go get authenticated and on the page FormResponseManager. So with this PR FormResponseManager has a boolean to tell weather backup responses has been loaded or not.

- Fix doSaveForBackup, formResponse updateStatus was null

- Fix : when user is not logged in, then validated a step and then go back to the previous step, the page crashed. With the PR, user go back to the previous next with transition with hightest priority