### PR TITLE
Review Lut 25281: Draft - Error when restoring a saved draft

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/service/FormService.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/FormService.java
@@ -474,6 +474,7 @@ public class FormService
         if ( CollectionUtils.isNotEmpty( listFormResponse ) )
         {
             formResponseManager = new FormResponseManager( listFormResponse.get( 0 ) );
+            formResponseManager.setIsResponseLoadedFromBackup(true);
         }
         else
         {

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
@@ -55,8 +55,15 @@ public class FormResponseManager
     private final List<Step> _listValidatedStep;
     private final FormResponse _formResponse;
     private boolean _bIsResponseLoadedFromBackup = false;
+    private boolean _isBackupResponseAlreadyInitiated = false;
 
 
+   public Boolean getIsBackupResponseAlreadyInitiated() {
+        return _isBackupResponseAlreadyInitiated;
+    }
+   public void setBackupResponseAlreadyInitiated(Boolean isBackupResponseAlreadyInitiated) {
+        _isBackupResponseAlreadyInitiated = isBackupResponseAlreadyInitiated;
+    }
 
     public Boolean getIsResponseLoadedFromBackup () {
         return _bIsResponseLoadedFromBackup;

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
@@ -58,32 +58,6 @@ public class FormResponseManager
     private boolean _isBackupResponseAlreadyInitiated = false;
     private HashMap<Integer, Timestamp> _mapIdStepVisited = new HashMap<Integer, Timestamp>( );
 
-
-   public Boolean getIsBackupResponseAlreadyInitiated() {
-        return _isBackupResponseAlreadyInitiated;
-    }
-   public void setBackupResponseAlreadyInitiated(Boolean isBackupResponseAlreadyInitiated) {
-        _isBackupResponseAlreadyInitiated = isBackupResponseAlreadyInitiated;
-    }
-
-    public Boolean getIsResponseLoadedFromBackup () {
-        return _bIsResponseLoadedFromBackup;
-    }
-    public void setIsResponseLoadedFromBackup (Boolean bIsResponseLoadedFromBackup) {
-        _bIsResponseLoadedFromBackup = bIsResponseLoadedFromBackup;
-    }
-
-    public void addMapIdStepVisited(int stepId) {
-        _mapIdStepVisited.put(Integer.valueOf(stepId),  Timestamp.valueOf(LocalDateTime.now()));
-    }
-    public void removeLastMapIdStepVisited(){
-        _mapIdStepVisited = _mapIdStepVisited.entrySet().stream().sorted(Map.Entry.comparingByValue()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
-                (oldValue, newValue) -> oldValue, LinkedHashMap::new));
-        // remove the last one
-        _mapIdStepVisited.remove(_mapIdStepVisited.keySet().toArray()[_mapIdStepVisited.size()-1]);    }
-    public HashMap<Integer, Timestamp> getMapIdStepVisited (){
-       return _mapIdStepVisited;
-    }
     /**
      * Constructor
      * 
@@ -179,6 +153,25 @@ public class FormResponseManager
     		updateDate = formResponseFromDB != null ? formResponseFromDB.getUpdate() : null;
     	}
     	return updateDate;
+    }
+
+    public void setFormResponseUpdateDate(Timestamp updateDate)
+    {
+    	FormResponse formResponse = getFormResponse();
+    	formResponse.setUpdate(updateDate);
+    }
+    public Boolean getIsBackupResponseAlreadyInitiated() {
+        return _isBackupResponseAlreadyInitiated;
+    }
+    public void setBackupResponseAlreadyInitiated(Boolean isBackupResponseAlreadyInitiated) {
+        _isBackupResponseAlreadyInitiated = isBackupResponseAlreadyInitiated;
+    }
+
+    public Boolean getIsResponseLoadedFromBackup () {
+        return _bIsResponseLoadedFromBackup;
+    }
+    public void setIsResponseLoadedFromBackup (Boolean bIsResponseLoadedFromBackup) {
+        _bIsResponseLoadedFromBackup = bIsResponseLoadedFromBackup;
     }
 
     /**

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
@@ -159,13 +159,23 @@ public class FormResponseManager
     	FormResponse formResponse = getFormResponse();
     	formResponse.setUpdate(updateDate);
     }
+    /**
+     * Give a boolean indicating that indicates if view (getViewStep) has been initialized from backup
+     * So with _isBackupResponseAlreadyInitiated and _bIsResponseLoadedFromBackup we can deduce if it's the first time the getViewStep is loaded with the backup response
+     *
+     * @return a boolean indicating that indicates if view has been initialized from backup
+     */
     public Boolean getIsBackupResponseAlreadyInitiated() {
         return _isBackupResponseAlreadyInitiated;
     }
     public void setBackupResponseAlreadyInitiated(Boolean isBackupResponseAlreadyInitiated) {
         _isBackupResponseAlreadyInitiated = isBackupResponseAlreadyInitiated;
     }
-
+    /**
+     * Gives a boolean indicating if the response is loaded from backup
+     *
+     * @return a boolean indicating if the response is loaded from backup
+     */
     public Boolean getIsResponseLoadedFromBackup () {
         return _bIsResponseLoadedFromBackup;
     }

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
@@ -37,18 +37,9 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
+import fr.paris.lutece.plugins.forms.business.*;
 import org.apache.commons.collections.CollectionUtils;
 
-import fr.paris.lutece.plugins.forms.business.Control;
-import fr.paris.lutece.plugins.forms.business.ControlHome;
-import fr.paris.lutece.plugins.forms.business.ControlType;
-import fr.paris.lutece.plugins.forms.business.Form;
-import fr.paris.lutece.plugins.forms.business.FormQuestionResponse;
-import fr.paris.lutece.plugins.forms.business.FormResponse;
-import fr.paris.lutece.plugins.forms.business.FormResponseHome;
-import fr.paris.lutece.plugins.forms.business.FormResponseStep;
-import fr.paris.lutece.plugins.forms.business.Step;
 import fr.paris.lutece.plugins.forms.service.EntryServiceManager;
 import fr.paris.lutece.plugins.forms.util.FormsConstants;
 import fr.paris.lutece.plugins.forms.validation.IValidator;
@@ -63,6 +54,16 @@ public class FormResponseManager
 {
     private final List<Step> _listValidatedStep;
     private final FormResponse _formResponse;
+    private boolean _bIsResponseLoadedFromBackup = false;
+
+
+
+    public Boolean getIsResponseLoadedFromBackup () {
+        return _bIsResponseLoadedFromBackup;
+    }
+    public void setIsResponseLoadedFromBackup (Boolean bIsResponseLoadedFromBackup) {
+        _bIsResponseLoadedFromBackup = bIsResponseLoadedFromBackup;
+    }
 
     /**
      * Constructor
@@ -342,6 +343,7 @@ public class FormResponseManager
         }
 
         return step;
+
     }
 
     /**

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
@@ -38,6 +38,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import fr.paris.lutece.plugins.forms.business.*;
+import fr.paris.lutece.portal.service.util.AppLogService;
 import org.apache.commons.collections.CollectionUtils;
 
 import fr.paris.lutece.plugins.forms.service.EntryServiceManager;
@@ -56,8 +57,6 @@ public class FormResponseManager
     private final FormResponse _formResponse;
     private boolean _bIsResponseLoadedFromBackup = false;
     private boolean _isBackupResponseAlreadyInitiated = false;
-    private HashMap<Integer, Timestamp> _mapIdStepVisited = new HashMap<Integer, Timestamp>( );
-
     /**
      * Constructor
      * 
@@ -209,16 +208,16 @@ public class FormResponseManager
     {
         if ( isStepValidated( step ) )
         {
-            throw new IllegalStateException( "The step is already validated !" );
-        }
+            AppLogService.error("The step is already validated !" );
+        } else {
 
-        _listValidatedStep.add( step );
+            _listValidatedStep.add(step);
 
-        FormResponseStep formResponseStep = findFormResponseStepFor( step );
+            FormResponseStep formResponseStep = findFormResponseStepFor(step);
 
-        if ( formResponseStep == null )
-        {
-            _formResponse.getSteps( ).add( createFormResponseStepFrom( step ) );
+            if (formResponseStep == null) {
+                _formResponse.getSteps().add(createFormResponseStepFrom(step));
+            }
         }
     }
 

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
@@ -34,10 +34,11 @@
 package fr.paris.lutece.plugins.forms.web;
 
 import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.List;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.stream.Collectors;
 import fr.paris.lutece.plugins.forms.business.*;
+import fr.paris.lutece.portal.service.util.AppLogService;
 import org.apache.commons.collections.CollectionUtils;
 
 import fr.paris.lutece.plugins.forms.service.EntryServiceManager;
@@ -55,16 +56,7 @@ public class FormResponseManager
     private final List<Step> _listValidatedStep;
     private final FormResponse _formResponse;
     private boolean _bIsResponseLoadedFromBackup = false;
-
-
-
-    public Boolean getIsResponseLoadedFromBackup () {
-        return _bIsResponseLoadedFromBackup;
-    }
-    public void setIsResponseLoadedFromBackup (Boolean bIsResponseLoadedFromBackup) {
-        _bIsResponseLoadedFromBackup = bIsResponseLoadedFromBackup;
-    }
-
+    private boolean _isBackupResponseAlreadyInitiated = false;
     /**
      * Constructor
      * 
@@ -162,6 +154,35 @@ public class FormResponseManager
     	return updateDate;
     }
 
+    public void setFormResponseUpdateDate(Timestamp updateDate)
+    {
+    	FormResponse formResponse = getFormResponse();
+    	formResponse.setUpdate(updateDate);
+    }
+    /**
+     * Give a boolean indicating that indicates if view (getViewStep) has been initialized from backup
+     * So with _isBackupResponseAlreadyInitiated and _bIsResponseLoadedFromBackup we can deduce if it's the first time the getViewStep is loaded with the backup response
+     *
+     * @return a boolean indicating that indicates if view has been initialized from backup
+     */
+    public Boolean getIsBackupResponseAlreadyInitiated() {
+        return _isBackupResponseAlreadyInitiated;
+    }
+    public void setBackupResponseAlreadyInitiated(Boolean isBackupResponseAlreadyInitiated) {
+        _isBackupResponseAlreadyInitiated = isBackupResponseAlreadyInitiated;
+    }
+    /**
+     * Gives a boolean indicating if the response is loaded from backup
+     *
+     * @return a boolean indicating if the response is loaded from backup
+     */
+    public Boolean getIsResponseLoadedFromBackup () {
+        return _bIsResponseLoadedFromBackup;
+    }
+    public void setIsResponseLoadedFromBackup (Boolean bIsResponseLoadedFromBackup) {
+        _bIsResponseLoadedFromBackup = bIsResponseLoadedFromBackup;
+    }
+
     /**
      * Initializes the steps order
      */
@@ -197,16 +218,16 @@ public class FormResponseManager
     {
         if ( isStepValidated( step ) )
         {
-            throw new IllegalStateException( "The step is already validated !" );
-        }
+            AppLogService.error("The step is already validated !" );
+        } else {
 
-        _listValidatedStep.add( step );
+            _listValidatedStep.add(step);
 
-        FormResponseStep formResponseStep = findFormResponseStepFor( step );
+            FormResponseStep formResponseStep = findFormResponseStepFor(step);
 
-        if ( formResponseStep == null )
-        {
-            _formResponse.getSteps( ).add( createFormResponseStepFrom( step ) );
+            if (formResponseStep == null) {
+                _formResponse.getSteps().add(createFormResponseStepFrom(step));
+            }
         }
     }
 

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormResponseManager.java
@@ -34,8 +34,8 @@
 package fr.paris.lutece.plugins.forms.web;
 
 import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.List;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.stream.Collectors;
 import fr.paris.lutece.plugins.forms.business.*;
 import org.apache.commons.collections.CollectionUtils;
@@ -56,6 +56,7 @@ public class FormResponseManager
     private final FormResponse _formResponse;
     private boolean _bIsResponseLoadedFromBackup = false;
     private boolean _isBackupResponseAlreadyInitiated = false;
+    private HashMap<Integer, Timestamp> _mapIdStepVisited = new HashMap<Integer, Timestamp>( );
 
 
    public Boolean getIsBackupResponseAlreadyInitiated() {
@@ -72,6 +73,17 @@ public class FormResponseManager
         _bIsResponseLoadedFromBackup = bIsResponseLoadedFromBackup;
     }
 
+    public void addMapIdStepVisited(int stepId) {
+        _mapIdStepVisited.put(Integer.valueOf(stepId),  Timestamp.valueOf(LocalDateTime.now()));
+    }
+    public void removeLastMapIdStepVisited(){
+        _mapIdStepVisited = _mapIdStepVisited.entrySet().stream().sorted(Map.Entry.comparingByValue()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                (oldValue, newValue) -> oldValue, LinkedHashMap::new));
+        // remove the last one
+        _mapIdStepVisited.remove(_mapIdStepVisited.keySet().toArray()[_mapIdStepVisited.size()-1]);    }
+    public HashMap<Integer, Timestamp> getMapIdStepVisited (){
+       return _mapIdStepVisited;
+    }
     /**
      * Constructor
      * 

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
@@ -467,6 +467,8 @@ public class FormXPage extends MVCApplication
         }
         try
         {
+            // The condition below : We don't want to fill the FormResponseManager when just logged in with response made when user wasn't logged in
+            // in case you are at step 2, you log in and you have to go back to step 1 that you already saved in backup
             if(_formResponseManager.getIsBackupResponseAlreadyInitiated() && _formResponseManager.getIsResponseLoadedFromBackup()
             || !_formResponseManager.getIsResponseLoadedFromBackup()) {
                 FormsResponseUtils.fillResponseManagerWithResponses(request, false, _formResponseManager, _stepDisplayTree.getQuestions(), false);
@@ -980,7 +982,9 @@ public class FormXPage extends MVCApplication
         }
 
         checkAuthentication( form, request );
-
+        if(_formResponseManager.getCurrentStep() == null) {
+            _formResponseManager.add(StepHome.getInitialStep(form.getId()));
+        }
         try
         {
         	FormsResponseUtils.fillResponseManagerWithResponses( request, false, _formResponseManager, _stepDisplayTree.getQuestions( ), false );
@@ -991,7 +995,6 @@ public class FormXPage extends MVCApplication
         }
 
         LuteceUser user = SecurityService.getInstance( ).getRegisteredUser( request );
-
         FormResponse formResponse = _formResponseManager.getFormResponse( );
         formResponse.setGuid( user.getName( ) );
         formResponse.setUpdateStatus(Timestamp.valueOf(LocalDateTime.now()));

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
@@ -154,7 +154,6 @@ public class FormXPage extends MVCApplication
     private IBreadcrumb _breadcrumb;
     private boolean _bInactiveStateBypassed;
     private boolean IsRequestComingFromAction = false;
-    private HashMap<Integer, Timestamp> _mapIdStepVisited = new HashMap<Integer, Timestamp>( );
 
     /**
      * Return the default XPage with the list of all available Form
@@ -362,12 +361,9 @@ public class FormXPage extends MVCApplication
             }
         }
         if(_formResponseManager.getCurrentStep() != null) {
-            System.out.println("current step : " + _formResponseManager.getCurrentStep().getId());
-            _mapIdStepVisited.put(_formResponseManager.getCurrentStep().getId(), Timestamp.valueOf(LocalDateTime.now()));
+            _formResponseManager.addMapIdStepVisited(_formResponseManager.getCurrentStep().getId());
         } else {
-            System.out.println("current step : " +StepHome.getInitialStep(form.getId()).getId());
-
-            _mapIdStepVisited.put(StepHome.getInitialStep(form.getId()).getId(), Timestamp.valueOf(LocalDateTime.now()));
+            _formResponseManager.addMapIdStepVisited((StepHome.getInitialStep(form.getId()).getId()));
         }
         IsRequestComingFromAction = false;
         XPage xPage = getXPage( TEMPLATE_VIEW_STEP, getLocale( request ), model );
@@ -489,11 +485,8 @@ public class FormXPage extends MVCApplication
         _formResponseManager.popStep();
         if( _formResponseManager.getValidatedSteps().size() == 1) {
             // order _mapIdStepVisited by timestamp the oldest is the last one
-            _mapIdStepVisited = _mapIdStepVisited.entrySet().stream().sorted(Map.Entry.comparingByValue()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
-                    (oldValue, newValue) -> oldValue, LinkedHashMap::new));
-            // remove the last one
-            _mapIdStepVisited.remove(_mapIdStepVisited.keySet().toArray()[_mapIdStepVisited.size()-1]);
-            int previousStepId = _mapIdStepVisited.keySet().toArray()[_mapIdStepVisited.size()-1].hashCode();
+         _formResponseManager.removeLastMapIdStepVisited();
+            int previousStepId = _formResponseManager.getMapIdStepVisited().keySet().toArray()[_formResponseManager.getMapIdStepVisited().size()-1].hashCode();
             _currentStep = StepHome.findByPrimaryKey(previousStepId);
         } else {
             _currentStep = _formResponseManager.getCurrentStep();

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
@@ -470,9 +470,9 @@ public class FormXPage extends MVCApplication
         try
         {
             // The condition below : We don't want to fill the FormResponseManager when just logged in with response made when user wasn't logged in
-            // in case you are at step 2, you log in and you have to go back to step 1 that you already saved in backup
+            //for exemple in case you are at step 2, you log in and you have to go back to step 1 that you already saved in backup
             if(_formResponseManager.getIsBackupResponseAlreadyInitiated() && _formResponseManager.getIsResponseLoadedFromBackup()
-            || !_formResponseManager.getIsResponseLoadedFromBackup()) {
+            || !_formResponseManager.getIsResponseLoadedFromBackup() && _formResponseManager.getFormResponse().getCreation() != null) {
                 FormsResponseUtils.fillResponseManagerWithResponses(request, false, _formResponseManager, _stepDisplayTree.getQuestions(), false);
             }
         }

--- a/webapp/WEB-INF/templates/skin/plugins/forms/composite_template/view_step.html
+++ b/webapp/WEB-INF/templates/skin/plugins/forms/composite_template/view_step.html
@@ -10,6 +10,7 @@
   	<input type="hidden" name="token" value = "${token}">
 	<input name="page" value="forms" type="hidden">
 	<input name="id_form" value="${step.idForm}" type="hidden">
+      <input name="id_step" value="${step.id}" type="hidden">
 	<#if !step.initial><button class="btn btn-primary btn-sm" name="action_doReturnStep"  type="submit" >#i18n{forms.step.previous}</button></#if>
 	<#if step.final>
       <#if form.displaySummary >


### PR DESCRIPTION
Fix access backup response to user, on forms that has the "save backup response" enable and no "mandatory authentication".
The problem was due to FormResponseManager not null (the condition to load backup responses), if you first go to first go to the page, FormResponseManager intanciates (before user logs in), and doesn't loaded the backup responses.
To make it work, different conditions has been implemented.
Has well, there are some changes with some of the "throw error", that has been change for with AppLogService.error, then a redirect so the view can loaded with the proper datas. 

Fix doSaveForBackup, formResponse updateStatus was null



To test the changes you need to add that dependency : 
 <dependency>
            <groupId>fr.paris.lutece.plugins</groupId>
            <artifactId>module-mylutece-database</artifactId>
            <version>[6.0.4-SNAPSHOT,)</version>
            <type>lutece-plugin</type>
        </dependency>

Then you can create users and a form that has backup response enable. 
Go on the form, fill steps (or not), save back up response, try to retrieve after with an another session ... 


